### PR TITLE
Custom Activator Class Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ module.exports = {
 
 ## Variants generated
 
-**Note:** _This variants are activated when the `html` or `body` has the class `dark-mode`_.
+**Note:** These variants can be activated when the `html` or `body` has the class `dark-mode`. 
+
+You can customize the default activator in the constructor for the plugin `require('tailwindcss-darkmode')('dark', 'dark-mode')`. The first parameter of the constructor is the prefix of `dark:hover` the second parameter is the class applied to the `html` or `body` tag. 
 
 - `dark`
 - `dark:hover`

--- a/index.js
+++ b/index.js
@@ -1,56 +1,56 @@
-module.exports = function(prefix = 'dark') {
+module.exports = function(prefix = 'dark', activator = 'dark-mode') {
   return function({ addVariant, e }) {
     addVariant(prefix, ({ modifySelectors, separator }) => {
       modifySelectors(({ className }) => {
-        return `.dark-mode .${e(`${prefix}${separator}${className}`)}`;
+        return `.${activator} .${e(`${prefix}${separator}${className}`)}`;
       });
     });
 
     addVariant(`${prefix}:hover`, ({ modifySelectors, separator }) => {
       modifySelectors(({ className }) => {
-        return `.dark-mode .${e(`${prefix}:hover${separator}${className}`)}:hover`;
+        return `.${activator} .${e(`${prefix}:hover${separator}${className}`)}:hover`;
       });
     });
 
     addVariant(`${prefix}:focus`, ({ modifySelectors, separator }) => {
       modifySelectors(({ className }) => {
-        return `.dark-mode .${e(`${prefix}:focus${separator}${className}`)}:focus`;
+        return `.${activator} .${e(`${prefix}:focus${separator}${className}`)}:focus`;
       });
     });
 
     addVariant(`${prefix}:active`, ({ modifySelectors, separator }) => {
       modifySelectors(({ className }) => {
-        return `.dark-mode .${e(`${prefix}:active${separator}${className}`)}:active`;
+        return `.${activator} .${e(`${prefix}:active${separator}${className}`)}:active`;
       });
     });
 
     addVariant(`${prefix}:disabled`, ({ modifySelectors, separator }) => {
       modifySelectors(({ className }) => {
-        return `.dark-mode .${e(`${prefix}:disabled${separator}${className}`)}:disabled`;
+        return `.${activator} .${e(`${prefix}:disabled${separator}${className}`)}:disabled`;
       });
     });
 
     addVariant(`${prefix}:group-hover`, ({ modifySelectors, separator }) => {
       modifySelectors(({ className }) => {
-        return `.dark-mode .group:hover .${e(`${prefix}:group-hover${separator}${className}`)}`;
+        return `.${activator} .group:hover .${e(`${prefix}:group-hover${separator}${className}`)}`;
       });
     });
 
     addVariant(`${prefix}:focus-within`, ({ modifySelectors, separator }) => {
       modifySelectors(({ className }) => {
-        return `.dark-mode .${e(`${prefix}:focus-within${separator}${className}`)}:focus-within`;
+        return `.${activator} .${e(`${prefix}:focus-within${separator}${className}`)}:focus-within`;
       });
     });
 
     addVariant(`${prefix}:odd`, ({ modifySelectors, separator }) => {
       modifySelectors(({ className }) => {
-        return `.dark-mode .${e(`${prefix}:odd${separator}${className}`)}:nth-child(odd)`;
+        return `.${activator} .${e(`${prefix}:odd${separator}${className}`)}:nth-child(odd)`;
       });
     });
 
     addVariant(`${prefix}:even`, ({ modifySelectors, separator }) => {
       modifySelectors(({ className }) => {
-        return `.dark-mode .${e(`${prefix}:even${separator}${className}`)}:nth-child(even)`;
+        return `.${activator} .${e(`${prefix}:even${separator}${className}`)}:nth-child(even)`;
       });
     });
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@danestves/tailwindcss-darkmode",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Tailwind CSS plugin that adds variants for DarkMode",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
This adds the ability to customize the activator class on the body. By default it is 'dark-mode' , but some people may like the option to change this.

First Param is the prefix to `dark:mode` or whatever you want it to be. `cats:hover`
Second Param is the activator on the `html` or `body` tag. `dark-mode` or to stick with my above example `cats`

**Default**
`require(tailwindcss-darkmode)('dark', 'dark-mode')`
**Custom**
`require(tailwindcss-darkmode)('dark', 'cats')`

I also updated the version number to 1.15